### PR TITLE
Refactor Code Gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Example usage and the expected spec of the `JSON` files can be found at `/Source
 
 Available enums (namespaces) containing tokens: `TokenColors, TokenSpacing and TokenRadius`.
 
-> ⚠️ **NOTE**: Only the semantic palette is exposed as code
+> ⚠️ **NOTE**: Only the semantic palette is exposed as code.
+> ⚪️⚫️ **NOTE**: The Dark and Light versions of the color will be combined into a single UIColor token using Dynamic Provider, thus it will be handled automatically when user changes to Light/Dark mode.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Swift Package Manager (SPM) package responsible for creating `Swift` code based 
 
 Example usage and the expected spec of the `JSON` files can be found at `/Sources/MEGADesignToken`.
 
-Available enums (namespaces) containing tokens: `MEGADesignTokenDarkColors, MEGADesignTokenLightColors, MEGADesignTokenSpacing and MEGADesignTokenRadius`.
+Available enums (namespaces) containing tokens: `TokenColors, TokenSpacing and TokenRadius`.
 
 > ⚠️ **NOTE**: Only the semantic palette is exposed as code
 
@@ -17,10 +17,10 @@ After adding `MEGADesignToken` as a package dependency, use it as:
 ```swift
 import MEGADesignToken
 
-let darkColorExample = MEGADesignTokenDarkColors.Background.backgroundBlur // UIColor
-let lightColorExample = MEGADesignTokenLightColors.Background.backgroundBlur // UIColor
-let spacingExample = MEGADesignTokenSpacing._1 // CGFloat
-let radiusExample = MEGADesignTokenRadius.small // CGFloat
+let uiKitColorExample = TokenColors.Background.blur // UIColor
+let swiftUIColorExample = TokenColors.Button.brandPressed.swiftUI // Color
+let spacingExample = TokenSpacing._1 // CGFloat
+let radiusExample = TokenRadius.small // CGFloat
 ```
 
 ### Custom palette

--- a/Sources/Executables/TokenCodegenGenerator/codegen.swift
+++ b/Sources/Executables/TokenCodegenGenerator/codegen.swift
@@ -121,7 +121,7 @@ private func generateSemanticTopLevelEnum(from input: CodegenInput) throws -> En
     let combinedData = mergeColorData(lightData: input.light.data, darkData: input.dark.data)
     let memberBlockBuilder = {
         try MemberBlockItemListSyntax {
-            for (enumName, category) in combinedData {
+            for (enumName, category) in combinedData.sorted(by: { $0.key < $1.key }) {
                 try generateSemanticEnum(for: enumName, category: category)
                     .with(\.leadingTrivia, .newlines(2))
             }
@@ -156,7 +156,7 @@ private func generateSemanticEnum(
     category: [String: (light: ColorInfo, dark: ColorInfo)]
 ) throws -> EnumDeclSyntax {
     let memberBlock = try MemberBlockSyntax {
-        for (variableName, info) in category {
+        for (variableName, info) in category.sorted(by: { $0.key < $1.key }) {
             try generateSemanticVariable(
                 for: variableName,
                 parentName: name,

--- a/Sources/Executables/TokenCodegenGenerator/codegen.swift
+++ b/Sources/Executables/TokenCodegenGenerator/codegen.swift
@@ -22,9 +22,9 @@ enum NumberInput {
     var identifier: String {
         switch self {
         case .radius:
-            return "MEGADesignTokenRadius"
+            return "TokenRadius"
         case .spacing:
-            return "MEGADesignTokenSpacing"
+            return "TokenSpacing"
         }
     }
 }
@@ -37,15 +37,6 @@ enum SemanticInput {
         switch self {
         case .dark(let data), .light(let data):
             return data
-        }
-    }
-
-    var identifier: String {
-        switch self {
-        case .dark:
-            return "MEGADesignTokenDarkColors"
-        case .light:
-            return "MEGADesignTokenLightColors"
         }
     }
 }
@@ -73,8 +64,8 @@ func generateCode(with input: CodegenInput) throws -> String {
 private func generateSourceFileSyntax(from input: CodegenInput) throws -> SourceFileSyntax {
     try SourceFileSyntax {
         generateImport()
-        try generateSemanticTopLevelEnum(with: input.dark)
-        try generateSemanticTopLevelEnum(with: input.light)
+        generateSwiftUIExtensions()
+        try generateSemanticTopLevelEnum(from: input)
         generateNumberTopLevelEnum(with: input.spacing)
         generateNumberTopLevelEnum(with: input.radius)
     }
@@ -82,16 +73,52 @@ private func generateSourceFileSyntax(from input: CodegenInput) throws -> Source
 
 private func generateImport() -> ImportDeclSyntax {
     let importPath = ImportPathComponentListSyntax {
-        .init(leadingTrivia: .space, name: .identifier("UIKit"), trailingTrivia: .newline)
+        .init(leadingTrivia: .space, name: .identifier("SwiftUI"), trailingTrivia: .newline)
     }
 
     return ImportDeclSyntax(importKeyword: .keyword(.import), path: importPath)
 }
 
-private func generateSemanticTopLevelEnum(with input: SemanticInput) throws -> EnumDeclSyntax {
+private func generateSwiftUIExtensions() -> DeclSyntax {
+    DeclSyntax(stringLiteral:
+        """
+        public extension UIColor {
+            var swiftUI: Color {
+                if #available(iOS 15, *) {
+                    Color(uiColor: self)
+                } else {
+                    Color(self)
+                }
+            }
+        }
+        """
+    )
+}
+
+private func mergeColorData(
+    lightData: ColorData,
+    darkData: ColorData
+) -> [String: [String: (light: ColorInfo, dark: ColorInfo)]] {
+    var mergedData = [String: [String: (light: ColorInfo, dark: ColorInfo)]]()
+
+    for (key, lightValues) in lightData {
+        guard let darkValues = darkData[key] else { continue }
+
+        for (innerKey, lightColorInfo) in lightValues {
+            if let darkColorInfo = darkValues[innerKey] {
+                mergedData[key, default: [:]][innerKey] = (light: lightColorInfo, dark: darkColorInfo)
+            }
+        }
+    }
+
+    return mergedData
+}
+
+private func generateSemanticTopLevelEnum(from input: CodegenInput) throws -> EnumDeclSyntax {
+    let combinedData = mergeColorData(lightData: input.light.data, darkData: input.dark.data)
     let memberBlockBuilder = {
         try MemberBlockItemListSyntax {
-            for (enumName, category) in input.data {
+            for (enumName, category) in combinedData {
                 try generateSemanticEnum(for: enumName, category: category)
             }
         }
@@ -100,7 +127,7 @@ private func generateSemanticTopLevelEnum(with input: SemanticInput) throws -> E
     return try EnumDeclSyntax(
         leadingTrivia: .newline,
         modifiers: [.init(name: .keyword(.public, trailingTrivia: .space))],
-        name: .identifier(input.identifier, leadingTrivia: .space, trailingTrivia: .space),
+        name: .identifier("TokenColors", leadingTrivia: .space, trailingTrivia: .space),
         memberBlockBuilder: memberBlockBuilder,
         trailingTrivia: .newline
     )
@@ -109,7 +136,7 @@ private func generateSemanticTopLevelEnum(with input: SemanticInput) throws -> E
 private func generateNumberTopLevelEnum(with input: NumberInput) -> EnumDeclSyntax {
     let memberBlockBuilder = {
         MemberBlockItemListSyntax {
-            for (name, info) in input.data {
+            for (name, info) in input.data.sorted(by: { $0.value < $1.value }) {
                 generateNumberVariable(for: name, info: info)
             }
         }
@@ -124,10 +151,18 @@ private func generateNumberTopLevelEnum(with input: NumberInput) -> EnumDeclSynt
     )
 }
 
-private func generateSemanticEnum(for name: String, category: [String: ColorInfo]) throws -> EnumDeclSyntax {
+private func generateSemanticEnum(
+    for name: String,
+    category: [String: (light: ColorInfo, dark: ColorInfo)]
+) throws -> EnumDeclSyntax {
     let memberBlock = try MemberBlockSyntax {
-        for (name, info) in category {
-            try generateSemanticVariable(for: name, with: info)
+        for (variableName, info) in category {
+            try generateSemanticVariable(
+                for: variableName,
+                parentName: name,
+                lightColorInfo: info.light,
+                darkColorInfo: info.dark
+            )
         }
     }
 
@@ -145,24 +180,38 @@ private func generateNumberVariable(for name: String, info: NumberInfo) -> DeclS
     return DeclSyntax(
     """
     \n
+    /// \(raw: Int(info.value))pt
     public static let \(raw: variableName) = CGFloat(\(raw: info.value))
     \n
     """
     )
 }
 
-private func generateSemanticVariable(for name: String, with info: ColorInfo) throws -> DeclSyntax {
-    guard let rbga = info.rgba else {
-        throw CodegenError.inputIsWrong(reason: "Codegen: unable to parse Color(\(name))")
+private func generateSemanticVariable(
+    for name: String,
+    parentName: String,
+    lightColorInfo: ColorInfo,
+    darkColorInfo: ColorInfo
+) throws -> DeclSyntax {
+    guard let lightRgba = lightColorInfo.rgba else {
+        throw CodegenError.inputIsWrong(reason: "Codegen: unable to parse light version of Color(\(name))")
     }
 
-    let variableName = name.sanitizeSemanticVariableName()
+    guard let darkRgba = darkColorInfo.rgba else {
+        throw CodegenError.inputIsWrong(reason: "Codegen: unable to parse dark version of Color(\(name))")
+    }
+
+    let variableName = name.sanitizeSemanticVariableName(with: parentName)
 
     return DeclSyntax(
-    """
-    \n
-    public static let \(raw: variableName) = UIColor(red: \(raw: rbga.red), green: \(raw: rbga.green), blue: \(raw: rbga.blue), alpha: \(raw: rbga.alpha))
-    \n
-    """
+        """
+        \n
+        public static let \(raw: variableName) = UIColor(dynamicProvider: { traitCollection in
+            return traitCollection.userInterfaceStyle == .light
+                ? UIColor(red: \(raw: lightRgba.red), green: \(raw: lightRgba.green), blue: \(raw: lightRgba.blue), alpha: \(raw: lightRgba.alpha))
+                : UIColor(red: \(raw: darkRgba.red), green: \(raw: darkRgba.green), blue: \(raw: darkRgba.blue), alpha: \(raw: darkRgba.alpha))
+        })
+        \n
+        """
     )
 }

--- a/Sources/Executables/TokenCodegenGenerator/extensions.swift
+++ b/Sources/Executables/TokenCodegenGenerator/extensions.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 extension String {
     func toCGFloat() -> CGFloat? {
@@ -42,11 +43,24 @@ extension String {
             .lowercased()
     }
 
-    func sanitizeSemanticVariableName() -> String {
-        self // Semantic colors have a format of '--color-foo-bar', so we'll make it 'fooBar'
-            .deletingPrefix("--color-")
+    func sanitizeSemanticVariableName(with parentName: String) -> String {
+        self
+            .deletingPrefix("--color-") // Semantic colors have a format of '--color-foo-bar', so we'll make it 'fooBar'
+            .removeSubstringIfNotWholeWord(parentName)
             .replacingOccurrences(of: "-", with: " ")
             .toCamelCase()
+    }
+
+    func removeSubstringIfNotWholeWord(_ substringToRemove: String) -> String {
+        if self.lowercased() == substringToRemove.lowercased() {
+            return self
+        } else {
+            return self.replacingOccurrences(
+                of: substringToRemove,
+                with: "",
+                options: .caseInsensitive
+            )
+        }
     }
 
     func sanitizeNumberVariableName() -> String {

--- a/Sources/Executables/TokenCodegenGenerator/model.swift
+++ b/Sources/Executables/TokenCodegenGenerator/model.swift
@@ -23,13 +23,17 @@ struct RGBA {
 
 typealias ColorData = [String: [String: ColorInfo]]
 
-struct NumberInfo: Decodable {
+struct NumberInfo: Decodable, Comparable {
     let type: String
     let value: Double
 
     enum CodingKeys: String, CodingKey {
         case type = "$type"
         case value = "$value"
+    }
+
+    static func < (lhs: NumberInfo, rhs: NumberInfo) -> Bool {
+        lhs.value < rhs.value
     }
 }
 

--- a/Sources/MEGADesignToken/Examples/MEGADesignTokenExample.swift
+++ b/Sources/MEGADesignToken/Examples/MEGADesignTokenExample.swift
@@ -1,13 +1,13 @@
 private struct MEGADesignTokenExample {
     init() {
         // Example usage of four available generated enums
-        let darkColorExample = MEGADesignTokenDarkColors.Background.backgroundBlur // UIColor
-        let lightColorExample = MEGADesignTokenLightColors.Background.backgroundBlur // UIColor
-        let spacingExample = MEGADesignTokenSpacing._1 // CGFloat
-        let radiusExample = MEGADesignTokenRadius.small // CGFloat
+        let uiKitColorExample = TokenColors.Background.blur // UIColor
+        let swiftUIColorExample = TokenColors.Button.brandPressed.swiftUI // Color
+        let spacingExample = TokenSpacing._1 // CGFloat
+        let radiusExample = TokenRadius.small // CGFloat
 
-        print(String(describing: darkColorExample))
-        print(String(describing: lightColorExample))
+        print(String(describing: uiKitColorExample))
+        print(String(describing: swiftUIColorExample))
         print(String(describing: spacingExample))
         print(String(describing: radiusExample))
     }

--- a/Tests/MEGADesignTokenTests/TokenCodegenGeneratorTests.swift
+++ b/Tests/MEGADesignTokenTests/TokenCodegenGeneratorTests.swift
@@ -223,7 +223,7 @@ final class TokenCodegenGeneratorTests: XCTestCase {
     }
 
     func testSanitizeSemanticVariableName_removesExtraneousInformation() {
-        XCTAssertEqual("--color-foo-bar".sanitizeSemanticVariableName(), "fooBar")
+        XCTAssertEqual("--color-parent-foo-bar".sanitizeSemanticVariableName(with: "parent"), "fooBar")
     }
 
     func testSanitizeNumberVariableName_withNumericString_prependsUnderscore() {


### PR DESCRIPTION
In this MR I did several refactorings to improve the code generation.

### Merged light and dark version into a single dynamic UI color
![Screenshot 2023-11-24 at 22 24 11](https://github.com/meganz/MEGADesignToken/assets/132426322/2238a3be-6244-4e41-b7aa-45478358a2a8)


### Add documentations to the number enums, so user can check the value at a glance
![Screenshot 2023-11-24 at 22 24 49](https://github.com/meganz/MEGADesignToken/assets/132426322/459664b9-4e8c-4c7b-b261-824040df0bcb)
![Screenshot 2023-11-24 at 22 25 05](https://github.com/meganz/MEGADesignToken/assets/132426322/6e83ef52-40ed-47b1-be32-4166327c0c63)


### Sanitize variable names to remove redundancy
Remove redundant names like `TokenColors.Background.backgroundBlur`.
Now it will be generated as `TokenColors.Background.blur`.

However there's several issues:
1. There are some colors that have the parent name `Notifications` but in the color its `notificationError` without the plural.
2. There are some colors that have the exact name as the parent, so I exclude it. Thus it will still be `TokenColors.Focus.focus`

### Add swiftUI color extension to UIColor
![Screenshot 2023-11-24 at 22 27 10](https://github.com/meganz/MEGADesignToken/assets/132426322/81f276e9-277a-4ebb-b544-860d1fd01cd3)

### Refactor the formatting so the code is more readable
![Screenshot 2023-11-24 at 22 27 33](https://github.com/meganz/MEGADesignToken/assets/132426322/64d6a488-a5a1-4e93-b239-7d805ca00145)

